### PR TITLE
Bulk Insert and Insert Route. Docstrings.

### DIFF
--- a/app.py
+++ b/app.py
@@ -62,26 +62,7 @@ def get_csv():
     return template('<pre>{{o}}</pre>', o=output.getvalue())
 
 
-# Creates a new table
-@route('/insert/<rows>')
-def insert(rows):
-    reader_list = csv.DictReader(io.StringIO(rows))
-    print(reader_list)
-    header = reader_list.fieldnames
-    print(type(header))
-    h = ",".join("\'"+str(x)+"\'" for x in header)
-    print(h)
-    statement = 'INSERT INTO t1 VALUES({h})'.format(h=h)
-    print(statement)
-
-    db.execute(statement)
-    db.commit()
-
-    return "Ran: \r" + statement
-
-
 # Insert bulk rows
-@route('/bulkinsert/<rows>')
 def binsert(rows):
     reg = re.compile('(?:[^,(]|\([^)]*\))*')
     data = [item.rstrip(")").lstrip("(").split(", ")
@@ -95,7 +76,23 @@ def binsert(rows):
     except:
         # TODO Try to catch the exception
         raise
-    return "Successfully input %s" % rows
+    return "Successfully inserted %s" % rows
+
+
+@route('/insert/<rows>')
+def insert(rows):
+    # TODO Fix both imports to reuse parts so that bulk and simple are same
+    if rows.startswith("("):
+        binsert(rows)
+        return binsert(rows)
+    else:
+        reader_list = csv.DictReader(io.StringIO(rows))
+        header = reader_list.fieldnames
+        h = ",".join("\'"+str(x)+"\'" for x in header)
+        statement = 'INSERT INTO t1 VALUES({h})'.format(h=h)
+        db.execute(statement)
+        db.commit()
+        return "Successfully inserted: \r" + statement
 
 
 # Creates a new table

--- a/app.py
+++ b/app.py
@@ -34,6 +34,7 @@ db = sqlite3.connect("db.sqlite")
 # Renders the table
 @route('/')
 def print_items():
+    """Print the data in the database in a tabular form"""
     cursor = db.execute('SELECT * FROM t1')
     # FIXME handle no database case with grace
     # FIXME Set number of rows to be x
@@ -45,6 +46,7 @@ def print_items():
 # Sends the sqlite file
 @route('/download')
 def get_sqlite():
+    """Get the sqlite file and download it"""
     response.headers['Content-Disposition'] = \
         'attachment; filename="database.sqlite"'
     buffer = io.StringIO()
@@ -57,6 +59,7 @@ def get_sqlite():
 # Sends the csv of the db
 @route('/csv')
 def get_csv():
+    """Get the csv file from the database"""
     cursor = db.execute('SELECT * FROM t1')
     header = list(map(lambda x: x[0], cursor.description))
     csvdata = cursor.fetchall()
@@ -69,17 +72,27 @@ def get_csv():
     return template('<pre>{{o}}</pre>', o=output.getvalue())
 
 
-def get_first():
+def get_one():
+    """Get one row of the database"""
     cursor = db.execute("SELECT * FROM t1 LIMIT 1")
     return cursor.fetchall()
 
 
 @route('/insert/<rows>')
 def insert(rows):
+    """Insert/Bulk insert values into the table.
+
+    Parameter
+    --------
+    rows : str
+        A long string equal to the number of columns in the database
+        setup. Each column value is separated by a comma and or by
+        delineating each row with a bracket.
+    """
     # TODO Try to handle special characters that are difficult
     global no_cols
     if no_cols is None:
-        no_cols = len(get_first()[0])
+        no_cols = len(get_one()[0])
     rd = csv.DictReader(io.StringIO(rows))
     try:
         # TODO Figure out what errors could occur
@@ -97,6 +110,15 @@ def insert(rows):
 # Creates a new table
 @route('/init/<rows>')
 def init(rows):
+    """Initialize a new table with 'n' columns
+
+    Parameter
+    ---------
+    rows : string
+        The rows indicate the column names of the columns in the table.
+        Each of columns are separated by a comma to indicate that they
+        are to be takend as the name of the column in the table.
+    """
     global no_cols
     reader_list = csv.DictReader(io.StringIO(rows))
     header = reader_list.fieldnames

--- a/app.py
+++ b/app.py
@@ -17,6 +17,8 @@ __author__ = "Antoni Kaniowski"
 __version__ = "0.1"
 __license__ = "wtfpl"
 
+# Store number of rows just to handle properly
+no_rows = None
 # Check if file exists, if not, bootstrap it from the sample
 db_file = Path("db.sqlite")
 if not db_file.is_file():
@@ -30,6 +32,7 @@ db = sqlite3.connect("db.sqlite")
 def print_items():
     cursor = db.execute('SELECT * FROM t1')
     # FIXME handle no database case with grace
+    # FIXME Set number of rows to be x
     return template('table.html',
                     headings=list(map(lambda x: x[0], cursor.description)),
                     items=cursor.fetchall())
@@ -71,6 +74,7 @@ def binsert(rows):
     # TODO Fix the import so that it is quite fast
     # --
     try:
+        # TODO FIXME execute many for multiple values for multiple columns
         db.executemany("INSERT INTO t1 VALUES (?, ?)", dta)
         db.commit()
     except:
@@ -98,9 +102,10 @@ def insert(rows):
 # Creates a new table
 @route('/init/<rows>')
 def init(rows):
+    global no_rows
     reader_list = csv.DictReader(io.StringIO(rows))
     header = reader_list.fieldnames
-
+    no_rows = len(header)
     try:
         h = " varchar, ".join(str(x) for x in header)
         statement = 'CREATE TABLE t1 ({h} varchar)'.format(h=h)

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@
 """[application description here]"""
 
 
+import re
 import io
 import csv
 import sqlite3
@@ -81,15 +82,16 @@ def insert(rows):
 @route('/bulkinsert/<rows>')
 def binsert(rows):
     print(rows)
-    reg_stmnt = '(?:[^,(]|\([^)]*\))+)'
-    data = rows.rstrip(")").lstrip("(").split("),(")
+    reg = re.compile('(?:[^,(]|\([^)]*\))*')
+    data = reg.findall(rows)
     print(data)
+    # --
     for item in data:
-        statement = '''INSERT INTO t1 VALUES ({h})'''.format(h=item)
-        print(statement)
+        statement = '''INSERT INTO t1 VALUES({h})'''.format(h=item)
         db.execute(statement)
+    # --
     db.commit()
-    return "Ran: \r" + data
+    return data
 
 
 # Creates a new table

--- a/app.py
+++ b/app.py
@@ -83,21 +83,19 @@ def insert(rows):
 # Insert bulk rows
 @route('/bulkinsert/<rows>')
 def binsert(rows):
-    print(rows)
     reg = re.compile('(?:[^,(]|\([^)]*\))*')
-    data = reg.findall(rows)
-    print(data)
+    data = [item.rstrip(")").lstrip("(").split(", ")
+            for item in reg.findall(rows)]
+    dta = [tuple(item) for item in data if len(item) > 1]
+    # TODO Fix the import so that it is quite fast
     # --
-    for item in data:
-        if len(item) > 1:
-            test = tuple("\'" + str(x) + "\'" for x in item)
-            print(test)
-            statement = "INSERT INTO t1 VALUES %s" % item
-            print(statement)
-            db.execute(statement)
-    # --
-    db.commit()
-    return data
+    try:
+        db.executemany("INSERT INTO t1 VALUES (?, ?)", dta)
+        db.commit()
+    except:
+        # TODO Try to catch the exception
+        raise
+    return "Successfully input %s" % rows
 
 
 # Creates a new table

--- a/app.py
+++ b/app.py
@@ -67,6 +67,7 @@ def insert(rows):
     reader_list = csv.DictReader(io.StringIO(rows))
     header = reader_list.fieldnames
     h = ",".join("\'"+str(x)+"\'" for x in header)
+    print(h)
     statement = 'INSERT INTO t1 VALUES({h})'.format(h=h)
     print(statement)
 
@@ -74,6 +75,21 @@ def insert(rows):
     db.commit()
 
     return "Ran: \r" + statement
+
+
+# Insert bulk rows
+@route('/bulkinsert/<rows>')
+def binsert(rows):
+    print(rows)
+    reg_stmnt = '(?:[^,(]|\([^)]*\))+)'
+    data = rows.rstrip(")").lstrip("(").split("),(")
+    print(data)
+    for item in data:
+        statement = '''INSERT INTO t1 VALUES ({h})'''.format(h=item)
+        print(statement)
+        db.execute(statement)
+    db.commit()
+    return "Ran: \r" + data
 
 
 # Creates a new table

--- a/app.py
+++ b/app.py
@@ -90,19 +90,29 @@ def binsert(rows):
     return "Successfully inserted %s" % rows
 
 
+def get_first():
+    cursor = db.execute("SELECT * FROM t1 LIMIT 1")
+    return cursor.fetchall()
+
+
 @route('/insert/<rows>')
 def insert(rows):
     # TODO Fix both imports to reuse parts so that bulk and simple are same
     global no_cols
     if no_cols is None:
-        no_cols = 2
+        no_cols = len(get_first()[0])
     # --
     rd = csv.DictReader(io.StringIO(rows))
-    input_length = len(rd.fieldnames)
-    if input_length > no_cols:
-        dta = [item.rstrip(")").lstrip(" (") for item in rd.fieldnames]
-        data = list(grouper(no_cols, dta))
-        print(data)
+    # --
+    dta = [item.rstrip(")").lstrip(" (") for item in rd.fieldnames]
+    data = list(grouper(no_cols, dta))
+    # --
+    fields = ("?, " * no_cols).rstrip(", ")
+    command = "INSERT INTO t1 VALUES (%s)" % fields
+    # --
+    db.executemany(command, data)
+    db.commit()
+    return "Successfully inserted %s" % rows
 #    if rows.startswith("("):
 #        binsert(rows)
 #        return binsert(rows)

--- a/app.py
+++ b/app.py
@@ -66,7 +66,9 @@ def get_csv():
 @route('/insert/<rows>')
 def insert(rows):
     reader_list = csv.DictReader(io.StringIO(rows))
+    print(reader_list)
     header = reader_list.fieldnames
+    print(type(header))
     h = ",".join("\'"+str(x)+"\'" for x in header)
     print(h)
     statement = 'INSERT INTO t1 VALUES({h})'.format(h=h)
@@ -87,8 +89,12 @@ def binsert(rows):
     print(data)
     # --
     for item in data:
-        statement = '''INSERT INTO t1 VALUES({h})'''.format(h=item)
-        db.execute(statement)
+        if len(item) > 1:
+            test = tuple("\'" + str(x) + "\'" for x in item)
+            print(test)
+            statement = "INSERT INTO t1 VALUES %s" % item
+            print(statement)
+            db.execute(statement)
     # --
     db.commit()
     return data

--- a/readme.mdown
+++ b/readme.mdown
@@ -16,8 +16,17 @@
   Initialize a new table (all columns are ``varchar``) 
   * ``/init/col_1,col_2,...``
 
-  Insert data:
-  * ``/insert/A_string,"12.2"...``
+  Single Insert
+  * Implicit: ``insert/col1, col2``
+  * For empty values: ``/insert/col1,None``
+
+  Bulk Insert
+  * Explicit:  ``/insert/(col1, col2),(col1, col2), (col1, col2),...``
+  * Implicit Bulk Insert: ``/insert/col1, col2, col1, col2, col1, col2,...``
+      * For 3 columns: ``/insert/col1, col2, col3, col1, col2, col3,...`` and so on for n columns.
+  * Empty columns should be clearly specified:
+      * ``/insert/col1,,col2,,col2,...``
+      * Or using: ``/insert/(col1,),(col1,col2),(,col2),...``
 
   View:
   * ``/``

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,10 @@
+"""
+Utilities
+"""
+import itertools
+
+
+# Create groups from data
+def grouper(n, iterable, fillVal=None):
+    args = [iter(iterable)] * n
+    return itertools.zip_longest(fillvalue=fillVal, *args)


### PR DESCRIPTION
The bulk insert and insert routes are now shared under `insert/`. The insert route tries to force most of the insert statements into `execute many` sql statement.
- The number of columns is inferred from the database if the value is not stored on application initialization.
- The insert route handles the input string in two ways:
  - Strings are automatically split based on the number of columns in the database.
  - Multiple rows of data can be handled using the insert route.
- Added docstrings to all the routes
- Utils.py script stores random recipes utilized for the new insert route.
- cleaned up some of the old code.
